### PR TITLE
Spawn ReRun viewer on startup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,14 @@ endif()
 
 # Rerun
 include(FetchContent)
-FetchContent_Declare(rerun_sdk URL https://github.com/rerun-io/rerun/releases/download/0.15.1/rerun_cpp_sdk.zip)
+FetchContent_Declare(rerun_sdk URL
+    https://github.com/rerun-io/rerun/releases/latest/download/rerun_cpp_sdk.zip)
 FetchContent_MakeAvailable(rerun_sdk)
 
 # eCAL
 find_package(eCAL REQUIRED)
 find_package(Protobuf REQUIRED)
+
 
 # Compile protobuf
 add_subdirectory(protos)

--- a/src/ISubscriberLogger.hpp
+++ b/src/ISubscriberLogger.hpp
@@ -11,18 +11,16 @@ constexpr char NODE_NAME[] = "ReRun eCAL Bridge";
 
 class ISubscriberLogger {
   public:
+    ISubscriberLogger(std::shared_ptr<rerun::RecordingStream> rec_stream)
+        : m_rec_stream(rec_stream){};
+
     virtual ~ISubscriberLogger() = 0 {};
 
     void setup(const eCAL::Monitoring::STopicMon& topic) {
         entity_path = topic.uname + "/" + topic.tname;
     }
 
-    inline static rerun::RecordingStream& logger() {
-        static bool connect = true;
-
-        if (connect) {
-            connect = m_rec_stream.spawn() != rerun::Error::ok();
-        }
+    inline std::shared_ptr<rerun::RecordingStream> logger() {
         return m_rec_stream;
     }
 
@@ -34,6 +32,5 @@ class ISubscriberLogger {
     std::string entity_path;
     eCAL::CSubscriber subscriber;
 
-  private:
-    inline static rerun::RecordingStream m_rec_stream = rerun::RecordingStream(NODE_NAME);
+    std::shared_ptr<rerun::RecordingStream> m_rec_stream;
 };

--- a/src/ReRunLogger.cpp
+++ b/src/ReRunLogger.cpp
@@ -3,6 +3,9 @@
 using namespace std::chrono_literals;
 
 void ReRunLogger::execute() {
+    // Start ReRun logger
+    m_rec_stream->spawn();
+
     while (eCAL::Ok()) {
         update_topics();
     }
@@ -43,10 +46,12 @@ void ReRunLogger::update_topics() {
 void ReRunLogger::create_logger(const eCAL::Monitoring::STopicMon& topic) {
     const std::string message_type = topic.tdatatype.name;
     if (message_type == "pb.rerun.Image") {
-        m_subscribers.insert({topic.tname, std::unique_ptr<ImageLogger>(new ImageLogger(topic))});
+        m_subscribers.insert(
+            {topic.tname, std::unique_ptr<ImageLogger>(new ImageLogger(topic, m_rec_stream))}
+        );
     } else if (message_type == "pb.rerun.Points3D") {
         m_subscribers.insert(
-            {topic.tname, std::unique_ptr<Points3dLogger>(new Points3dLogger(topic))}
+            {topic.tname, std::unique_ptr<Points3dLogger>(new Points3dLogger(topic, m_rec_stream))}
         );
     }
 }

--- a/src/ReRunLogger.hpp
+++ b/src/ReRunLogger.hpp
@@ -22,6 +22,10 @@ class ReRunLogger {
     // eCAL Subscribers
     std::map<std::string, std::unique_ptr<ISubscriberLogger>> m_subscribers;
 
+    // ReRun Logger
+    std::shared_ptr<rerun::RecordingStream> m_rec_stream =
+        std::make_shared<rerun::RecordingStream>(NODE_NAME);
+
     void get_topics(std::map<std::string, eCAL::Monitoring::STopicMon>& topics);
 
     void update_topics();

--- a/src/loggers/ImageLogger.hpp
+++ b/src/loggers/ImageLogger.hpp
@@ -6,7 +6,10 @@
 
 class ImageLogger : public ISubscriberLogger {
   public:
-    ImageLogger(const eCAL::Monitoring::STopicMon& topic) {
+    ImageLogger(
+        const eCAL::Monitoring::STopicMon& topic, std::shared_ptr<rerun::RecordingStream> rec_stream
+    )
+        : ISubscriberLogger(rec_stream) {
         subscriber = eCAL::protobuf::CSubscriber<pb::rerun::Image>(topic.tname);
         subscriber.AddReceiveCallback(std::bind(&ImageLogger::log, this, std::placeholders::_2));
 
@@ -18,14 +21,6 @@ class ImageLogger : public ISubscriberLogger {
 
         pb::rerun::Image imagePb;
         imagePb.ParseFromArray(data_->buf, data_->size);
-
-        logger().log(
-            entity_path,
-            rerun::Image(
-                {imagePb.height(), imagePb.width(), imagePb.channels()},
-                (uint8_t*)imagePb.data().data()
-            )
-        );
     }
 
   private:

--- a/src/loggers/Points3dLogger.hpp
+++ b/src/loggers/Points3dLogger.hpp
@@ -6,7 +6,10 @@
 
 class Points3dLogger : public ISubscriberLogger {
   public:
-    Points3dLogger(const eCAL::Monitoring::STopicMon& topic) {
+    Points3dLogger(
+        const eCAL::Monitoring::STopicMon& topic, std::shared_ptr<rerun::RecordingStream> rec_stream
+    )
+        : ISubscriberLogger(rec_stream) {
         subscriber = eCAL::protobuf::CSubscriber<pb::rerun::Points3D>(topic.tname);
         subscriber.AddReceiveCallback(std::bind(&Points3dLogger::log, this, std::placeholders::_2));
 
@@ -41,7 +44,7 @@ class Points3dLogger : public ISubscriberLogger {
             radii[i] = points3dPb.radius(i);
         }
 
-        logger().log(entity_path, rerun::Points3D(points3d).with_colors(colors).with_radii(radii));
+        logger()->log(entity_path, rerun::Points3D(points3d).with_colors(colors).with_radii(radii));
     }
 
   private:


### PR DESCRIPTION
## Changelog

- Rerun viewer is now launched automatically when the bridge starts.
- Image Logger needs to be rewritten due to API changes.